### PR TITLE
added a side bar to display filters and a load spinner while climbing routes load

### DIFF
--- a/components/ClimbingRoutes.js
+++ b/components/ClimbingRoutes.js
@@ -1,10 +1,21 @@
 import React, {Component} from 'react';
 import {connect} from 'react-redux';
 
+import {toggleFilterDrawer} from '../redux/actions.js';
 import {fetchClimbingRoutes} from '../redux/thunks/climbingRoutesThunks';
 import RouteTile from './RouteTile';
+import LoadSpinner from './LoadSpinner';
 
-import {Container, Header, Content, Text, Card, CardItem} from 'native-base';
+import {
+  Container,
+  Header,
+  Content,
+  Text,
+  Card,
+  CardItem,
+  Icon,
+  View,
+} from 'native-base';
 
 class climbingRoutes extends Component {
   constructor() {
@@ -44,39 +55,59 @@ class climbingRoutes extends Component {
   }
   render() {
     const {
-      props: {climbingRoutes, user, editModel},
+      props: {
+        climbingRoutes,
+        user,
+        editModel,
+        toggleFilterDrawer,
+        filterDrawer,
+      },
       filter,
     } = this;
     return (
       <Container>
-        <Content>
-          {climbingRoutes.map(climbingRoute => {
-            return filter(climbingRoute) ? (
-              <RouteTile
-                key={climbingRoute.id}
-                route={climbingRoute}
-                user={user}
-                editModel={editModel}
-              />
-            ) : (
-              ''
-            );
-          })}
-        </Content>
+        {climbingRoutes.length ? (
+          <Container>
+            <Icon
+              type="FontAwesome"
+              name="filter"
+              style={{margin: 5}}
+              onPress={toggleFilterDrawer}
+            />
+            <Content>
+              {climbingRoutes.map(climbingRoute => {
+                return filter(climbingRoute) ? (
+                  <RouteTile
+                    key={climbingRoute.id}
+                    route={climbingRoute}
+                    user={user}
+                    editModel={editModel}
+                  />
+                ) : (
+                  ''
+                );
+              })}
+            </Content>
+          </Container>
+        ) : (
+          <LoadSpinner />
+        )}
       </Container>
     );
   }
 }
 
-const mapState = ({climbingRoutes, user, routeFilters}) => ({
+const mapState = ({climbingRoutes, user, routeFilters, filterDrawer}) => ({
   climbingRoutes,
   user,
   routeFilters,
+  filterDrawer,
 });
 
 const mapDispatch = dispatch => {
   return {
     fetchClimbingRoutes: () => dispatch(fetchClimbingRoutes()),
+    toggleFilterDrawer: () => dispatch(toggleFilterDrawer()),
   };
 };
 

--- a/components/FilterDrawer.js
+++ b/components/FilterDrawer.js
@@ -1,0 +1,44 @@
+import React, {Component} from 'react';
+import Drawer from 'react-native-drawer';
+import {View, Text} from 'react-native';
+import ClimbingRoutes from './ClimbingRoutes';
+import {connect} from 'react-redux';
+import {Icon} from 'native-base';
+import {toggleFilterDrawer} from '../redux/actions.js';
+
+class FilterDrawer extends Component {
+  closeControlPanel = () => {
+    this._drawer.close();
+  };
+  openControlPanel = () => {
+    this._drawer.open();
+  };
+  render() {
+    return (
+      <Drawer
+        open={this.props.filterDrawer.show}
+        ref={ref => (this._drawer = ref)}
+        content={
+          <View>
+            <Text>Drawer Content</Text>
+            <Icon
+              type="FontAwesome"
+              name="close"
+              onPress={this.props.toggleFilterDrawer}
+            />
+          </View>
+        }>
+        <ClimbingRoutes />
+      </Drawer>
+    );
+  }
+}
+
+const mapState = ({filterDrawer}) => ({filterDrawer});
+const mapDispatch = dispatch => {
+  return {
+    toggleFilterDrawer: () => dispatch(toggleFilterDrawer()),
+  };
+};
+
+export default connect(mapState, mapDispatch)(FilterDrawer);

--- a/components/FilterSideBar.js
+++ b/components/FilterSideBar.js
@@ -1,0 +1,104 @@
+import React, {Component} from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  Image,
+  TouchableOpacity,
+  SafeAreaView,
+} from 'react-native';
+import SideMenu from 'react-native-side-menu';
+import Menu from './Menu';
+import {Icon} from 'native-base';
+
+const styles = StyleSheet.create({
+  button: {
+    position: 'absolute',
+    top: 20,
+    padding: 10,
+  },
+  caption: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    alignItems: 'center',
+  },
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#F5FCFF',
+  },
+  welcome: {
+    fontSize: 20,
+    textAlign: 'center',
+    margin: 10,
+  },
+  instructions: {
+    textAlign: 'center',
+    color: '#333333',
+    marginBottom: 5,
+  },
+});
+
+export default class FilterSideBar extends Component {
+  constructor(props) {
+    super(props);
+
+    this.toggle = this.toggle.bind(this);
+
+    this.state = {
+      isOpen: false,
+      selectedItem: 'About',
+    };
+  }
+
+  toggle() {
+    this.setState({
+      isOpen: !this.state.isOpen,
+    });
+  }
+
+  updateMenuState(isOpen) {
+    this.setState({isOpen});
+  }
+
+  onMenuItemSelected = item =>
+    this.setState({
+      isOpen: false,
+      selectedItem: item,
+    });
+
+  render() {
+    const menu = <Menu onItemSelected={this.onMenuItemSelected} />;
+
+    return (
+      <SafeAreaView>
+        <SideMenu
+          menu={menu}
+          isOpen={this.state.isOpen}
+          onChange={isOpen => this.updateMenuState(isOpen)}>
+          <View style={styles.container}>
+            <Text style={styles.welcome}>Welcome to React Native!</Text>
+            <Text style={styles.instructions}>
+              To get started, edit index.ios.js
+            </Text>
+            <Text style={styles.instructions}>
+              Press Cmd+R to reload,{'\n'}
+              Cmd+Control+Z for dev menu
+            </Text>
+            <Text style={styles.instructions}>
+              Current selected menu item is: {this.state.selectedItem}
+            </Text>
+          </View>
+          <TouchableOpacity onPress={this.toggle} style={styles.button}>
+            <Icon
+              type="FontAwesome"
+              name="filter"
+              style={{width: 32, height: 32}}
+            />
+          </TouchableOpacity>
+        </SideMenu>
+      </SafeAreaView>
+    );
+  }
+}

--- a/components/Home.js
+++ b/components/Home.js
@@ -1,17 +1,21 @@
 import React, {Component} from 'react';
-import {StyleSheet, Text, View, Image, SafeAreaView, TouchableOpacity} from 'react-native';
 import {
-  Header,
+  StyleSheet,
+  View,
+  Image,
+  SafeAreaView,
+  TouchableOpacity,
+} from 'react-native';
+import {
   LearnMoreLinks,
   Colors,
   DebugInstructions,
   ReloadInstructions,
 } from 'react-native/Libraries/NewAppScreen';
 
+import {Text} from 'native-base';
 import axios from 'axios';
-import {Button} from 'react-native-material-ui';
-import Topnav from './Topnav';
-import climbingRoutes from './ClimbingRoutes'; 
+import climbingRoutes from './ClimbingRoutes';
 
 export default class Home extends Component {
   allClimbingRoutes = () => {
@@ -20,10 +24,11 @@ export default class Home extends Component {
   render() {
     return (
       <SafeAreaView>
-        <Topnav />
-        <TouchableOpacity  onPress={this.allClimbingRoutes}>
-          <Text> Cllimbing Routes  </Text>
-        </TouchableOpacity>
+        <View>
+          <TouchableOpacity onPress={this.allClimbingRoutes}>
+            <Text> Cllimbing Routes </Text>
+          </TouchableOpacity>
+        </View>
         <View style={styles.logoContainer}>
           <Text> Connect Collaborate & Create Amazing Climbing Routes </Text>
           <Image

--- a/components/LoadSpinner.js
+++ b/components/LoadSpinner.js
@@ -1,0 +1,14 @@
+import React, {Component} from 'react';
+import {Container, Header, Content, Spinner} from 'native-base';
+export default class LoadSpinner extends Component {
+  render() {
+    return (
+      <Container>
+        <Header />
+        <Content>
+          <Spinner />
+        </Content>
+      </Container>
+    );
+  }
+}

--- a/components/Menu.js
+++ b/components/Menu.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Dimensions,
+  StyleSheet,
+  ScrollView,
+  View,
+  Image,
+  Text,
+} from 'react-native';
+
+const window = Dimensions.get('window');
+const uri = 'https://pickaface.net/gallery/avatar/Opi51c74d0125fd4.png';
+
+const styles = StyleSheet.create({
+  menu: {
+    flex: 1,
+    width: window.width,
+    height: window.height,
+    backgroundColor: 'gray',
+    padding: 20,
+  },
+  avatarContainer: {
+    marginBottom: 20,
+    marginTop: 20,
+  },
+  avatar: {
+    width: 48,
+    height: 48,
+    borderRadius: 24,
+    flex: 1,
+  },
+  name: {
+    position: 'absolute',
+    left: 70,
+    top: 20,
+  },
+  item: {
+    fontSize: 14,
+    fontWeight: '300',
+    paddingTop: 5,
+  },
+});
+
+const Menu = ({onItemSelected}) => {
+  return (
+    <ScrollView scrollsToTop={false} style={styles.menu}>
+      <View style={styles.avatarContainer}>
+        <Image style={styles.avatar} source={{uri}} />
+        <Text style={styles.name}>Your name</Text>
+      </View>
+
+      <Text onPress={() => onItemSelected('About')} style={styles.item}>
+        About
+      </Text>
+
+      <Text onPress={() => onItemSelected('Contacts')} style={styles.item}>
+        Contacts
+      </Text>
+    </ScrollView>
+  );
+};
+
+Menu.propTypes = {
+  onItemSelected: PropTypes.func.isRequired,
+};
+
+export default Menu;

--- a/components/Routes.js
+++ b/components/Routes.js
@@ -4,19 +4,22 @@ import {createStackNavigator} from '@react-navigation/stack';
 import Login from './Login';
 import Home from './Home';
 import Signup from './Signup';
-import climbingRoutes from './ClimbingRoutes'; 
+import climbingRoutes from './ClimbingRoutes';
+import FilterDrawer from './FilterDrawer';
 const Stack = createStackNavigator();
 
 //function to create a new stack navigator, pass an object into function to configure what different screens we want to register for this stack navigator
-export default Navigator = () => {
+const Navigator = () => {
   return (
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen name="Login" component={Login} />
         <Stack.Screen name="Home" component={Home} />
         <Stack.Screen name="Signup" component={Signup} />
-        <Stack.Screen name="ClimbingRoutes" component={climbingRoutes}/> 
+        <Stack.Screen name="ClimbingRoutes" component={FilterDrawer} />
       </Stack.Navigator>
     </NavigationContainer>
   );
 };
+
+export default Navigator;

--- a/package-lock.json
+++ b/package-lock.json
@@ -7493,6 +7493,14 @@
         "debounce": "^1.2.0"
       }
     },
+    "react-native-side-menu": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/react-native-side-menu/-/react-native-side-menu-1.1.3.tgz",
+      "integrity": "sha1-bvXSIy7PcYMS32zt7wGRSLrDBzo=",
+      "requires": {
+        "prop-types": "^15.5.10"
+      }
+    },
     "react-native-tab-view": {
       "version": "github:react-navigation/react-native-tab-view#d87a5cb3ddbcb9e5ea1651450f6c12a7f41355df",
       "from": "github:react-navigation/react-native-tab-view",

--- a/package.json
+++ b/package.json
@@ -25,14 +25,15 @@
     "react-native-reanimated": "^1.7.0",
     "react-native-safe-area-context": "^0.7.3",
     "react-native-screens": "^2.4.0",
+    "react-native-side-menu": "^1.1.3",
     "react-native-vector-icons": "^6.6.0",
     "react-navigation": "^1.6.1",
+    "react-navigation-stack": "^2.3.4",
     "react-redux": "^7.2.0",
     "redux": "^4.0.5",
     "redux-devtools-extension": "^2.13.8",
     "redux-logger": "^3.0.6",
-    "redux-thunk": "^2.3.0",
-    "react-navigation-stack": "^2.3.4"
+    "redux-thunk": "^2.3.0"
   },
   "devDependencies": {
     "@babel/core": "7.8.7",

--- a/redux/actions.js
+++ b/redux/actions.js
@@ -14,7 +14,14 @@ import {
   LOGIN_SUCCESS,
   LOGIN_FAILURE,
   SET_EDIT_MODEL,
+  TOGGLE_FILTER_DRAWER,
 } from './constants';
+
+export const toggleFilterDrawer = () => {
+  return {
+    type: TOGGLE_FILTER_DRAWER,
+  };
+};
 
 export const setEditModel = (model, holdsData) => {
   return {

--- a/redux/constants.js
+++ b/redux/constants.js
@@ -13,3 +13,4 @@ export const SET_ROUTE_IMAGE = Symbol('SET_ROUTE_IMAGE');
 export const SET_ROUTE_VIDEO = Symbol('SET_ROUTE_VIDEO');
 export const LOGIN_SUCCESS = Symbol('LOGIN_SUCCESS');
 export const LOGIN_FAILURE = Symbol('LOGIN_FAILURE');
+export const TOGGLE_FILTER_DRAWER = Symbol('TOGGLE_FILTER_DRAWER');

--- a/redux/index.js
+++ b/redux/index.js
@@ -10,6 +10,7 @@ import {
   routeFilters,
   routeImage,
   logInAuth,
+  filterDrawer,
 } from './reducers';
 
 export default combineReducers({
@@ -22,4 +23,5 @@ export default combineReducers({
   routeFilters,
   routeImage,
   logInAuth,
+  filterDrawer,
 });

--- a/redux/reducers.js
+++ b/redux/reducers.js
@@ -13,10 +13,21 @@ import {
   LOGIN_SUCCESS,
   LOGIN_FAILURE,
   SET_EDIT_MODEL,
+  TOGGLE_FILTER_DRAWER,
 } from './constants';
 import {htmlDate} from '../utils';
 import moment from 'moment';
 import {fetchHolds} from './thunks/holdThunks';
+
+export const filterDrawer = (state = {show: false}, action) => {
+  switch (action.type) {
+    case TOGGLE_FILTER_DRAWER:
+      const newState = {show: !state.show};
+      return newState;
+    default:
+      return state;
+  }
+};
 
 export const routeFilters = (state = {}, action) => {
   switch (action.type) {


### PR DESCRIPTION
Changes this PR: 
 - Added a filter icon to the top of ClimbingRoutes. When clicked it displays a side bar
 - Added a FilterDrawer component that will contain filter options for climbing routes
 - Added a LoadSpinner component that displays on ClimbingRoutes until the routes are loaded

Acceptance Criteria:
1. Pull this branch
2. `npm i`
3. `cd ios`
4. `rm -rf Pods`
5. `pod install`
6. `cd ..`
7. `npx react-native link`
8. `npm run ios`
9. Login -> click climbing routes
10. See a load spinner display if the route list doesn't load immediately
11. Click the filter button at the top of ClimbingRoutes to display FilterDrawer
12. Click the close button to hide FilterDrawer